### PR TITLE
refactor: extract shared logic to FolderCommentCore module

### DIFF
--- a/AFC.ps1
+++ b/AFC.ps1
@@ -1,0 +1,64 @@
+param (
+    [string]$F,
+    [string]$C,
+    [switch]$h
+)
+
+# 导入核心模块
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$modulePath = Join-Path $scriptDir 'FolderCommentCore.psm1'
+if (-not (Test-Path $modulePath)) {
+    # 尝试从当前目录加载
+    $modulePath = Join-Path (Get-Location) 'FolderCommentCore.psm1'
+}
+Import-Module $modulePath -Force
+
+# 设置日志
+$logPath = Join-Path $env:TEMP "ModifyFolderComment_$(Get-Date -Format 'yyyyMMdd').log"
+Set-LogFile -Path $logPath
+
+# 显示帮助信息
+if ($h) {
+    Write-Host "使用说明："
+    Write-Host "此脚本用于为指定的文件夹添加备注信息。"
+    Write-Host "参数："
+    Write-Host "  -F <string>  要添加备注的文件夹路径。"
+    Write-Host "  -C <string>  要添加的备注内容。"
+    Write-Host "  -h           显示帮助信息。"
+    Write-Host "示例："
+    Write-Host "  .\AFC.ps1 -F 'C:\示例文件夹' -C '这是备注信息。'"
+    exit
+}
+
+# 检查是否提供了必要的参数
+if (-not $F -or -not $C) {
+    Write-Host "错误：缺少必要的参数。请使用 -h 查看使用说明。"
+    exit 1
+}
+
+# 标准化路径
+$F = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($F)
+
+# 检查文件夹是否存在
+if (-not (Test-Path $F)) {
+    Write-Host "错误：指定的文件夹不存在。"
+    exit 1
+}
+
+# 验证是否为文件夹
+$item = Get-Item $F -Force
+if ($item -isnot [System.IO.DirectoryInfo]) {
+    Write-Host "错误：指定的路径不是文件夹。"
+    exit 1
+}
+
+try {
+    Set-FolderInfoTip -FolderPath $F -Comment $C
+    Write-OperationLog -Operation "SetComment" -FolderPath $F -Comment $C -Success $true
+    Write-Host "已成功为文件夹添加备注。"
+}
+catch {
+    Write-OperationLog -Operation "SetComment" -FolderPath $F -Comment $C -Success $false -ErrorMessage $_.Exception.Message
+    Write-Host "操作失败：$($_.Exception.Message)"
+    exit 1
+}

--- a/FolderCommentCore.psm1
+++ b/FolderCommentCore.psm1
@@ -228,7 +228,7 @@ function Invoke-FolderRefresh {
     # 清理残留文件
     try {
         Get-ChildItem -Path $FolderPath -Force -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -like "desktop*.ini" -or $_.Name -like "ini*.tmp" -or $_.Name -like "~$*" } |
+            Where-Object { $_.Name -like "desktop_*.ini" -or $_.Name -like "ini*.tmp" -or $_.Name -like "~$*" } |
             ForEach-Object {
                 Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
                 Write-Verbose "已清理残留文件: $($_.Name)"

--- a/FolderCommentCore.psm1
+++ b/FolderCommentCore.psm1
@@ -1,0 +1,280 @@
+# FolderCommentCore.psm1
+# 核心模块：文件夹备注的读写和刷新功能
+
+using namespace System.Runtime.InteropServices
+
+#region Native Methods
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class FolderCommentNative {
+    [DllImport("shell32.dll", SetLastError = true)]
+    public static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+}
+"@
+#endregion
+
+#region Comment Escaping
+function Escape-InfoTipComment {
+    param([string]$Comment)
+    # 转义注释内容，防止破坏 ini 格式
+    # 处理换行符（替换为空格，因为 InfoTip 通常是单行显示）
+    $escaped = $Comment -replace "[\r\n]+", " "
+    # 如果用户输入包含 InfoTip= 前缀，转义等号防止被识别为键
+    $escaped = $escaped -replace "^(InfoTip=)", "InfoTip\="
+    return $escaped
+}
+#endregion
+
+#region Core Functions
+function Get-FolderInfoTip {
+    <#
+    .SYNOPSIS
+        获取文件夹的备注信息
+    .PARAMETER FolderPath
+        文件夹路径
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FolderPath
+    )
+
+    $iniPath = Join-Path $FolderPath 'desktop.ini'
+    if (-not (Test-Path $iniPath)) {
+        return ""
+    }
+
+    try {
+        $iniContent = Get-Content $iniPath -Encoding Unicode -ErrorAction Stop
+        $inShellClassInfo = $false
+        foreach ($line in $iniContent) {
+            if ($line.Trim() -eq "[.ShellClassInfo]") {
+                $inShellClassInfo = $true
+                continue
+            }
+            if ($line.StartsWith("[") -and $line.EndsWith("]")) {
+                $inShellClassInfo = $false
+                continue
+            }
+            if ($inShellClassInfo -and $line.StartsWith("InfoTip=")) {
+                return $line.Substring("InfoTip=".Length)
+            }
+        }
+    }
+    catch {
+        # 读取失败，返回空字符串
+    }
+
+    return ""
+}
+
+function Set-FolderInfoTip {
+    <#
+    .SYNOPSIS
+        设置文件夹的备注信息
+    .PARAMETER FolderPath
+        文件夹路径
+    .PARAMETER Comment
+        备注内容
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FolderPath,
+        [Parameter(Mandatory = $true)]
+        [string]$Comment
+    )
+
+    $iniPath = Join-Path $FolderPath 'desktop.ini'
+
+    # 转义注释内容，防止注入
+    $escapedComment = Escape-InfoTipComment -Comment $Comment
+
+    # 读取现有内容或创建新的空列表
+    $lines = @()
+    if (Test-Path $iniPath) {
+        $lines = @($(Get-Content $iniPath -Encoding Unicode -ErrorAction Stop))
+    }
+
+    # 查找 [.ShellClassInfo] 节
+    $sectionIndex = -1
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        if ($lines[$i].Trim() -eq "[.ShellClassInfo]") {
+            $sectionIndex = $i
+            break
+        }
+    }
+
+    if ($sectionIndex -eq -1) {
+        # 节不存在，添加
+        $lines += "[.ShellClassInfo]"
+        $lines += "InfoTip=$escapedComment"
+    }
+    else {
+        # 节存在，查找或插入 InfoTip
+        $replaced = $false
+        for ($i = $sectionIndex + 1; $i -lt $lines.Length -and -not $lines[$i].StartsWith("["); $i++) {
+            if ($lines[$i].StartsWith("InfoTip=")) {
+                $lines[$i] = "InfoTip=$escapedComment"
+                $replaced = $true
+                break
+            }
+        }
+        if (-not $replaced) {
+            $newLines = @()
+            $newLines += $lines[0..$sectionIndex]
+            $newLines += "InfoTip=$escapedComment"
+            if ($sectionIndex + 1 -lt $lines.Length) {
+                $newLines += $lines[($sectionIndex + 1)..($lines.Length - 1)]
+            }
+            $lines = $newLines
+        }
+    }
+
+    # 清除只读属性
+    if (Test-Path $iniPath) {
+        [System.IO.File]::SetAttributes($iniPath, [System.IO.FileAttributes]::Normal)
+    }
+
+    # 写入更新后的内容（Unicode LE with BOM）
+    $bytes = [System.Text.Encoding]::Unicode.GetPreamble() +
+              ([System.Text.Encoding]::Unicode.GetBytes(($lines -join "`n") + "`n"))
+    [System.IO.File]::WriteAllBytes($iniPath, $bytes)
+
+    # 设置隐藏和系统属性
+    [System.IO.File]::SetAttributes($iniPath, [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
+
+    # 设置文件夹为系统文件夹
+    $dirInfo = Get-Item $FolderPath
+    $dirInfo.Attributes = $dirInfo.Attributes -bor [System.IO.FileAttributes]::System
+
+    # 执行刷新
+    Invoke-FolderRefresh -FolderPath $FolderPath
+}
+#endregion
+
+#region Folder Refresh with STA and Retry
+function Invoke-FolderRefresh {
+    <#
+    .SYNOPSIS
+        刷新文件夹显示，使 desktop.ini 更改立即生效
+    .PARAMETER FolderPath
+        文件夹路径
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FolderPath
+    )
+
+    if (-not (Test-Path $FolderPath)) {
+        return
+    }
+
+    $desktopIni = Join-Path $FolderPath 'desktop.ini'
+    if (-not (Test-Path $desktopIni)) {
+        Write-Verbose "desktop.ini 文件不存在"
+        return
+    }
+
+    # 使用后台作业在 STA 线程执行刷新
+    $job = Start-Job -ScriptBlock {
+        param($folderPath, $desktopIniPath)
+
+        Add-Type -AssemblyName System.Windows.Forms
+
+        $shell = $null
+        try {
+            # 拷贝 desktop.ini 到系统临时目录
+            $tempIni = Join-Path ([System.IO.Path]::GetTempPath()) "desktop_$([System.Guid]::NewGuid().ToString('N')).ini"
+            Copy-Item $desktopIniPath $tempIni -Force
+
+            # 确保临时文件有系统+隐藏属性
+            [System.IO.File]::SetAttributes($tempIni, [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
+
+            # 创建 Shell 对象
+            $shell = New-Object -ComObject Shell.Application
+            $folder = $shell.Namespace($folderPath)
+
+            if ($folder -ne $null) {
+                # 使用 MoveHere 拖入临时 ini 文件，模拟 Explorer 拷贝
+                # 参数: 4 (不显示进度) + 16 (响应"是"到所有询问) + 1024 (不显示UI)
+                $folder.MoveHere($tempIni, 4 + 16 + 1024)
+
+                # 等待资源管理器应用 desktop.ini
+                Start-Sleep -Milliseconds 150
+            }
+        }
+        finally {
+            # 释放 COM 对象
+            if ($shell -ne $null) {
+                [System.Runtime.Interopservices.Marshal]::ReleaseComObject($shell) | Out-Null
+            }
+        }
+
+        # 强制通知资源管理器
+        [FolderCommentNative]::SHChangeNotify(0x8000000, 0x1000, [IntPtr]::Zero, [IntPtr]::Zero)
+    } -ArgumentList $FolderPath, $desktopIni
+
+    # 等待作业完成（超时 5 秒）
+    $completed = Wait-Job -Job $job -Timeout 5
+    if ($completed) {
+        $result = Receive-Job -Job $job
+        if ($result) { Write-Verbose $result }
+    }
+    else {
+        Write-Verbose "刷新操作超时"
+    }
+    Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+
+    # 清理残留文件
+    try {
+        Get-ChildItem -Path $FolderPath -Force -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like "desktop*.ini" -or $_.Name -like "ini*.tmp" -or $_.Name -like "~$*" } |
+            ForEach-Object {
+                Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
+                Write-Verbose "已清理残留文件: $($_.Name)"
+            }
+    }
+    catch {
+        Write-Verbose "清理残留文件失败: $($_.Exception.Message)"
+    }
+}
+#endregion
+
+#region Logging
+$script:LogFile = $null
+
+function Set-LogFile {
+    param([string]$Path)
+    $script:LogFile = $Path
+}
+
+function Write-OperationLog {
+    param(
+        [string]$Operation,
+        [string]$FolderPath,
+        [string]$Comment,
+        [bool]$Success,
+        [string]$ErrorMessage = $null
+    )
+
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $logEntry = "$timestamp | $Operation | Path: $FolderPath | Success: $Success"
+    if ($ErrorMessage) {
+        $logEntry += " | Error: $ErrorMessage"
+    }
+
+    if ($script:LogFile) {
+        Add-Content -Path $script:LogFile -Value $logEntry -ErrorAction SilentlyContinue
+    }
+    Write-Verbose $logEntry
+}
+#endregion
+
+Export-ModuleMember -Function @(
+    'Get-FolderInfoTip',
+    'Set-FolderInfoTip',
+    'Invoke-FolderRefresh',
+    'Escape-InfoTipComment',
+    'Set-LogFile',
+    'Write-OperationLog'
+)

--- a/ModifyFolderComment.ps1
+++ b/ModifyFolderComment.ps1
@@ -1,8 +1,23 @@
-﻿# >>> Invoke-PS2EXE -InputFile "ModifyFolderComment.ps1" -OutputFile "ModifyFolderComment.exe" -NoConsole
+# >>> Invoke-PS2EXE -InputFile "ModifyFolderComment.ps1" -OutputFile "ModifyFolderComment.exe" -NoConsole -requireAdmin
 
 param (
-    [string]$FolderPath
+    [string]$FolderPath,
+    [string]$Comment,
+    [switch]$AdminElevated
 )
+
+# 导入核心模块
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$modulePath = Join-Path $scriptDir 'FolderCommentCore.psm1'
+if (-not (Test-Path $modulePath)) {
+    # 尝试从当前目录加载
+    $modulePath = Join-Path (Get-Location) 'FolderCommentCore.psm1'
+}
+Import-Module $modulePath -Force
+
+# 设置日志（可选，可通过 Set-LogFile 自定义路径）
+$logPath = Join-Path $env:TEMP "ModifyFolderComment_$(Get-Date -Format 'yyyyMMdd').log"
+Set-LogFile -Path $logPath
 
 Add-Type -AssemblyName System.Windows.Forms
 
@@ -13,8 +28,61 @@ function Test-Admin {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-if (-not (Test-Admin)) {
-    [System.Windows.Forms.MessageBox]::Show('请以管理员身份运行此程序，否则备注可能无法生效。', '权限不足', 'OK', 'Warning')
+# 尝试提权并重新调用自身
+function Invoke-ElevateAndSetInfoTip {
+    param(
+        [string]$folderPath,
+        [string]$comment
+    )
+
+    try {
+        $scriptPath = $PSCommandPath
+        if (-not $scriptPath) {
+            $scriptPath = $MyInvocation.MyCommand.Path
+        }
+
+        $arguments = "-File `"$scriptPath`" -FolderPath `"$folderPath`" -Comment `"$($comment.Replace('"', '\"'))`" -AdminElevated"
+
+        Start-Process powershell.exe -ArgumentList $arguments -Verb RunAs -Wait
+    }
+    catch {
+        [System.Windows.Forms.MessageBox]::Show("无法请求管理员权限：$($_.Exception.Message)", "权限不足", "OK", "Error")
+    }
+}
+
+# 检查是否是管理员模式的直接执行
+if ($AdminElevated -and $null -ne $Comment) {
+    try {
+        Set-FolderInfoTip -FolderPath $FolderPath -Comment $Comment
+        Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $Comment -Success $true
+        Write-Host "管理员模式执行成功"
+    }
+    catch {
+        Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $Comment -Success $false -ErrorMessage $_.Exception.Message
+        [System.Windows.Forms.MessageBox]::Show("以管理员权限修改失败：$($_.Exception.Message)", "错误", "OK", "Error")
+    }
+    exit
+}
+
+# 检查参数
+if ([string]::IsNullOrEmpty($FolderPath)) {
+    [System.Windows.Forms.MessageBox]::Show("请通过右键菜单或命令行指定文件夹路径。", "参数缺失", "OK", "Warning")
+    exit
+}
+
+# 标准化路径（处理末尾反斜杠、解析相对路径等）
+$FolderPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($FolderPath)
+
+# 验证路径是否真实存在
+if (-not (Test-Path $FolderPath)) {
+    [System.Windows.Forms.MessageBox]::Show("文件夹路径无效。", "错误", "OK", "Error")
+    exit
+}
+
+# 验证是否为文件夹
+$item = Get-Item $FolderPath -Force
+if ($item -isnot [System.IO.DirectoryInfo]) {
+    [System.Windows.Forms.MessageBox]::Show("指定的路径不是文件夹。", "错误", "OK", "Error")
     exit
 }
 
@@ -26,10 +94,6 @@ $form.StartPosition = "CenterScreen"
 $form.FormBorderStyle = "FixedDialog"
 $form.MaximizeBox = $false
 $form.MinimizeBox = $false
-
-# 设置 AcceptButton 和 CancelButton
-$form.AcceptButton = $null  # 暂时设置为 null，稍后指定
-$form.CancelButton = $null  # 先设为 null，后面再赋值
 
 # 添加标签
 $label = New-Object System.Windows.Forms.Label
@@ -45,24 +109,7 @@ $textBox.Location = New-Object System.Drawing.Point(10,50)
 $form.Controls.Add($textBox)
 
 # 获取现有备注并显示在文本框中
-$existingComment = $null
-$iniPath = Join-Path $FolderPath 'desktop.ini'
-
-if (Test-Path $iniPath) {
-    try {
-        $iniContent = Get-Content $iniPath -Encoding Unicode
-        foreach ($line in $iniContent) {
-            if ($line -match '^InfoTip\s*=\s*(.*)$') {
-                $existingComment = $matches[1].Trim()
-                break
-            }
-        }
-    }
-    catch {
-        # 读取 desktop.ini 失败，忽略
-    }
-}
-
+$existingComment = Get-FolderInfoTip -FolderPath $FolderPath
 if (-not [string]::IsNullOrWhiteSpace($existingComment)) {
     $textBox.Text = $existingComment
 }
@@ -72,15 +119,10 @@ $buttonOk = New-Object System.Windows.Forms.Button
 $buttonOk.Text = "确定"
 $buttonOk.Location = New-Object System.Drawing.Point(220,80)
 $buttonOk.Add_Click({
-    if (-not [string]::IsNullOrWhiteSpace($textBox.Text)) {
-        $form.Tag = $textBox.Text
-        $form.DialogResult = [System.Windows.Forms.DialogResult]::OK
-        $form.Close()
-    }
-    else {
-        $form.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
-        $form.Close()
-    }
+    $commentText = $textBox.Text.Trim()
+    $form.Tag = $commentText
+    $form.DialogResult = [System.Windows.Forms.DialogResult]::OK
+    $form.Close()
 })
 $form.Controls.Add($buttonOk)
 
@@ -109,238 +151,32 @@ if ($result -ne [System.Windows.Forms.DialogResult]::OK) {
 
 $comment = $form.Tag
 
-# 检查是否输入了备注
+# 即使是空备注也要处理（允许清空备注）
 if ($null -eq $comment) {
     exit
 }
 
 try {
-    # 设置文件夹属性为系统，以便 desktop.ini 生效
-    $folder = Get-Item $FolderPath
-    if (-not ($folder.Attributes -band [System.IO.FileAttributes]::System)) {
-        $folder.Attributes = $folder.Attributes -bor [System.IO.FileAttributes]::System
-    }
-
-    # 创建或修改 desktop.ini 文件
-    $iniPath = Join-Path $FolderPath 'desktop.ini'
-    $iniHash = @{}
-    if (Test-Path $iniPath) {
-        try {
-            # 确保能正确读取 desktop.ini，尝试不同编码
-            $iniContent = $null
-            try {
-                $iniContent = Get-Content $iniPath -Encoding Unicode -ErrorAction Stop
-            } catch {
-                try {
-                    $iniContent = Get-Content $iniPath -Encoding Default -ErrorAction Stop
-                } catch {
-                    $iniContent = Get-Content $iniPath -ErrorAction Stop
-                }
-            }
-
-            $currentSection = ''
-            foreach ($line in $iniContent) {
-                if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                if ($line -match '^[\[](.*)[\]]$') {
-                    $currentSection = $matches[1]
-                    if (-not $iniHash.ContainsKey($currentSection)) {
-                        $iniHash[$currentSection] = @{}
-                    }
-                } elseif ($line -match '^(.*?)=(.*)$') {
-                    $key = $matches[1].Trim()
-                    $value = $matches[2].Trim()
-                    if (-not [string]::IsNullOrEmpty($currentSection)) {
-                        $iniHash[$currentSection][$key] = $value
-                    }
-                }
-            }
-        } catch {
-            # 如果读取失败，创建新的 desktop.ini
-            Write-Host "无法读取 desktop.ini，将创建新文件: $_" -ForegroundColor Yellow
-        }
-    }
-
-    # 确保存在 .ShellClassInfo 节
-    if (-not $iniHash.ContainsKey('.ShellClassInfo')) {
-        $iniHash['.ShellClassInfo'] = @{}
-    }
-
-    # 设置备注信息
-    if ([string]::IsNullOrWhiteSpace($comment)) {
-        # 备注为空时删除 InfoTip 字段
-        $iniHash['.ShellClassInfo'].Remove('InfoTip') | Out-Null
-    } else {
-        $iniHash['.ShellClassInfo']['InfoTip'] = $comment
-    }
-
-    # 清理空节
-    $sectionsToRemove = @()
-    foreach ($section in $iniHash.Keys) {
-        if ($iniHash[$section].Count -eq 0) {
-            $sectionsToRemove += $section
-        }
-    }
-    foreach ($section in $sectionsToRemove) {
-        $iniHash.Remove($section)
-    }
-
-    # 写回 desktop.ini - 确保使用正确的格式和编码
-    $output = New-Object System.Collections.Generic.List[string]
-    foreach ($section in $iniHash.Keys) {
-        $output.Add("[$section]")
-        foreach ($key in $iniHash[$section].Keys) {
-            $value = $iniHash[$section][$key]
-            $output.Add("$key=$value")
-        }
-        $output.Add("")
-    }
-
-    # 确保目录为系统属性
-    $folder = Get-Item $FolderPath
-    if (-not ($folder.Attributes -band [System.IO.FileAttributes]::System)) {
-        $folder.Attributes = $folder.Attributes -bor [System.IO.FileAttributes]::System
-    }
-
-    # 如果存在旧文件，先删除它
-    if (Test-Path $iniPath) {
-        Remove-Item -Path $iniPath -Force
-    }
-
-    # 写入新的 desktop.ini 文件
-    Set-Content -Path $iniPath -Value $output -Encoding Unicode -Force
-
-    # 设置 desktop.ini 属性为隐藏和系统
-    [System.IO.File]::SetAttributes($iniPath, [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
-
-    # 直接在 PowerShell 中实现刷新机制，替代 ForceRefresh.vbs
-    try {
-        [System.Windows.Forms.MessageBox]::Show('开始执行刷新机制', '调试信息', 'OK', 'Information')
-
-        # 确保文件夹路径不为空且存在
-        if (-not [string]::IsNullOrEmpty($FolderPath) -and (Test-Path -Path $FolderPath -PathType Container)) {
-            # 设置当前 desktop.ini 文件路径
-            $desktopIniPath = Join-Path $FolderPath 'desktop.ini'
-            # 使用固定临时文件名，而非随机生成
-            $tempIniPath = Join-Path $FolderPath 'desktop.ini.tmp'
-
-            [System.Windows.Forms.MessageBox]::Show("刷新路径：$FolderPath`n设置备注：$comment`ndesktop.ini路径：$desktopIniPath", '调试信息', 'OK', 'Information')
-
-            # 等待文件系统操作完成
-            Start-Sleep -Milliseconds 200
-
-            # 获取 Shell.Application COM 对象
-            $shell = New-Object -ComObject Shell.Application
-            $folder = $shell.NameSpace($FolderPath)
-
-            # 使用 Try-Catch 块处理文件操作
-            try {
-                # 如果 desktop.ini 存在，先复制到临时文件
-                if (Test-Path -Path $desktopIniPath -PathType Leaf) {
-                    [System.Windows.Forms.MessageBox]::Show("desktop.ini 存在，执行复制操作", '调试信息', 'OK', 'Information')
-
-                    # 先删除可能存在的旧临时文件
-                    if (Test-Path -Path $tempIniPath) {
-                        Remove-Item -Path $tempIniPath -Force -ErrorAction SilentlyContinue
-                    }
-
-                    # 复制文件（不立即设置其属性）
-                    Copy-Item -Path $desktopIniPath -Destination $tempIniPath -Force -ErrorAction Stop
-
-                    # 确认临时文件创建成功后再操作
-                    Start-Sleep -Milliseconds 100
-                    if (Test-Path -Path $tempIniPath -PathType Leaf) {
-                        # 删除原始 desktop.ini (先删除目标后移动，避免权限问题)
-                        Remove-Item -Path $desktopIniPath -Force -ErrorAction SilentlyContinue
-
-                        # 检查删除是否成功
-                        if (-not (Test-Path -Path $desktopIniPath)) {
-                            [System.Windows.Forms.MessageBox]::Show("原始 desktop.ini 已删除，准备重命名临时文件", '调试信息', 'OK', 'Information')
-                        }
-
-                        # 先通过重命名移动文件，避免使用MoveHere导致的复杂性
-                        Rename-Item -Path $tempIniPath -NewName "desktop.ini" -Force
-
-                        # 确保设置了正确的文件属性
-                        if (Test-Path -Path $desktopIniPath -PathType Leaf) {
-                            [System.IO.File]::SetAttributes($desktopIniPath, [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
-                            [System.Windows.Forms.MessageBox]::Show("重命名成功并设置了属性", '调试信息', 'OK', 'Information')
-
-                            # 通过Shell的方式刷新缓存
-                            $folder.MoveHere($desktopIniPath, 4+16+1024)
-                            [System.Windows.Forms.MessageBox]::Show("已执行 MoveHere 刷新操作", '调试信息', 'OK', 'Information')
-                        }
-                    }
-                } else {
-                    [System.Windows.Forms.MessageBox]::Show("desktop.ini 不存在，无需刷新", '调试信息', 'OK', 'Information')
-                }
-            }
-            catch {
-                [System.Windows.Forms.MessageBox]::Show("文件操作失败: $_", '调试错误', 'OK', 'Error')
-
-                # 紧急恢复：确保保留desktop.ini文件
-                if ((-not (Test-Path -Path $desktopIniPath)) -and (Test-Path -Path $tempIniPath)) {
-                    try {
-                        Rename-Item -Path $tempIniPath -NewName "desktop.ini" -Force
-                        if (Test-Path -Path $desktopIniPath) {
-                            [System.IO.File]::SetAttributes($desktopIniPath, [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
-                            [System.Windows.Forms.MessageBox]::Show("紧急恢复完成", '调试信息', 'OK', 'Information')
-                        }
-                    }
-                    catch {
-                        [System.Windows.Forms.MessageBox]::Show("紧急恢复失败: $_", '调试错误', 'OK', 'Error')
-                    }
-                }
-            }
-            finally {
-                # 清理临时文件（如果还存在）
-                if (Test-Path -Path $tempIniPath) {
-                    try {
-                        Remove-Item -Path $tempIniPath -Force -ErrorAction SilentlyContinue
-                    }
-                    catch {
-                        # 忽略清理错误
-                    }
-                }
-
-                # 释放 COM 对象
-                try {
-                    if ($null -ne $folder) {
-                        [System.Runtime.Interopservices.Marshal]::ReleaseComObject($folder) | Out-Null
-                    }
-                    if ($null -ne $shell) {
-                        [System.Runtime.Interopservices.Marshal]::ReleaseComObject($shell) | Out-Null
-                    }
-                    [System.GC]::Collect()
-                    [System.GC]::WaitForPendingFinalizers()
-                }
-                catch {
-                    # 忽略 COM 对象释放错误
-                }
-            }
-        } else {
-            [System.Windows.Forms.MessageBox]::Show("文件夹路径无效: $FolderPath", '调试错误', 'OK', 'Error')
-        }
-    }
-    catch {
-        [System.Windows.Forms.MessageBox]::Show("刷新 shell 缓存失败: $_", '调试错误', 'OK', 'Error')
-        # 错误不会阻止主要功能
-    }
-
-    # 强制资源管理器刷新
-    Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-public class RefreshExplorer {
-    [DllImport("shell32.dll", SetLastError = true)]
-    public static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+    Set-FolderInfoTip -FolderPath $FolderPath -Comment $comment
+    Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $comment -Success $true
 }
-"@
-    [RefreshExplorer]::SHChangeNotify(0x08000000, 0x0000, [IntPtr]::Zero, [IntPtr]::Zero)
+catch [System.UnauthorizedAccessException] {
+    Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $comment -Success $false -ErrorMessage "UnauthorizedAccessException"
+    Invoke-ElevateAndSetInfoTip -folderPath $FolderPath -comment $comment
+}
+catch [System.IO.IOException] {
+    if ($_.Exception.HResult -eq -2147024891) {
+        Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $comment -Success $false -ErrorMessage "AccessDenied"
+        Invoke-ElevateAndSetInfoTip -folderPath $FolderPath -comment $comment
+    }
+    else {
+        Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $comment -Success $false -ErrorMessage $_.Exception.Message
+        [System.Windows.Forms.MessageBox]::Show("操作失败：$($_.Exception.Message)", "错误", "OK", "Error")
+    }
 }
 catch {
-    [System.Windows.Forms.MessageBox]::Show('操作失败：' + $_.Exception.Message, '错误', 'OK', 'Error')
-    exit
+    Write-OperationLog -Operation "SetComment" -FolderPath $FolderPath -Comment $comment -Success $false -ErrorMessage $_.Exception.Message
+    [System.Windows.Forms.MessageBox]::Show("操作失败：$($_.Exception.Message)", "错误", "OK", "Error")
 }
 
-# 确保脚本不返回任何内容
 exit

--- a/OPTIMIZATION_ISSUES.md
+++ b/OPTIMIZATION_ISSUES.md
@@ -1,0 +1,154 @@
+# Optimization Issues
+
+## 1. 优化 FolderRefresher 使用 STA 线程提升 COM 稳定性
+
+**状态**: ✅ 已完成
+
+**实现方式**:
+使用 `Start-Job` 在独立线程执行 COM 操作（虽然 PowerShell Start-Job 默认不是严格 STA，但避免了 MTA 的问题）
+
+**参考实现** (C# 版本已有):
+```csharp
+var t = new Thread(RefreshFolderStaParameterized);
+t.SetApartmentState(ApartmentState.STA);
+t.Start(folderPath);
+t.Join();
+```
+
+---
+
+## 2. 为 MoveHere 操作添加重试机制和超时控制
+
+**状态**: ⚠️ 部分完成（添加了超时，未实现重试）
+
+**当前实现**:
+```powershell
+$job = Start-Job -ScriptBlock { ... }
+$completed = Wait-Job -Job $job -Timeout 5
+```
+
+**待改进**: 可在刷新失败后增加重试逻辑（建议 3 次，递增等待时间）
+
+---
+
+## 3. 增强临时文件和残留文件的清理逻辑
+
+**状态**: ✅ 已完成
+
+**当前实现**:
+```powershell
+Get-ChildItem -Path $FolderPath -Force |
+    Where-Object {
+        $_.Name -like "desktop*.ini" -or
+        $_.Name -like "ini*.tmp" -or
+        $_.Name -like "~$*"
+    }
+```
+
+---
+
+## 4. 优化 SHChangeNotify 标志组合
+
+**状态**: ⏳ 未实现
+
+**当前代码**:
+```powershell
+[FolderCommentNative]::SHChangeNotify(0x8000000, 0x1000, [IntPtr]::Zero, [IntPtr]::Zero)
+```
+
+**待改进**: 可研究更精准的刷新标志组合
+
+---
+
+## 5. 添加长路径支持（\\?\ 前缀）
+
+**状态**: ⏳ 未实现
+
+**待改进**: 在 `$tempIni` 路径前添加 `\\?\` 前缀以支持超长路径
+
+---
+
+## 6. 代码重复问题
+
+**状态**: ✅ 已完成
+
+**解决方案**: 提取公共代码到 `FolderCommentCore.psm1` 模块
+
+| 文件 | 修改 |
+|------|------|
+| `ModifyFolderComment.ps1` | Import-Module，移除重复函数 |
+| `AFC.ps1` | Import-Module，移除重复函数 |
+| `FolderCommentCore.psm1` | 新增，包含所有核心功能 |
+
+---
+
+## 7. 注释注入漏洞
+
+**状态**: ✅ 已完成
+
+**问题**: 用户输入的 `InfoTip=` 或换行符可能破坏 ini 格式
+
+**解决方案**: `Escape-InfoTipComment` 函数转义处理
+```powershell
+function Escape-InfoTipComment {
+    $escaped = $Comment -replace "[\r\n]+", " "
+    $escaped = $escaped -replace "^(InfoTip=)", "InfoTip\="
+    return $escaped
+}
+```
+
+---
+
+## 8. COM 对象未释放
+
+**状态**: ✅ 已完成
+
+**实现**:
+```powershell
+finally {
+    if ($shell -ne $null) {
+        [System.Runtime.Interopservices.Marshal]::ReleaseComObject($shell) | Out-Null
+    }
+}
+```
+
+---
+
+## 9. 路径验证不足
+
+**状态**: ✅ 已完成
+
+**改进**:
+- 标准化路径（处理末尾反斜杠、解析相对路径）
+- 验证路径是否真实存在
+- 验证是否为文件夹类型
+
+```powershell
+$FolderPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($FolderPath)
+$item = Get-Item $FolderPath -Force
+if ($item -isnot [System.IO.DirectoryInfo]) { ... }
+```
+
+---
+
+## 10. VBS 包装器过时
+
+**状态**: ✅ 已完成
+
+**解决方案**:
+- `install_script.iss`: 改用 PowerShell 直接调用
+- `AddContextMenuOption.reg`: 改用 PowerShell 调用
+- `RunModifyFolderComment.ps1`: PowerShell 替代方案
+
+---
+
+## 11. 无操作日志
+
+**状态**: ✅ 已完成
+
+**实现**:
+```powershell
+# 日志文件位于 %TEMP%\ModifyFolderComment_yyyyMMdd.log
+Set-LogFile -Path $logPath
+Write-OperationLog -Operation "SetComment" -FolderPath $path -Comment $comment -Success $true
+```

--- a/RunModifyFolderComment.vbs
+++ b/RunModifyFolderComment.vbs
@@ -1,4 +1,32 @@
 Set objShell = CreateObject("Shell.Application")
+Set objFSO = CreateObject("Scripting.FileSystemObject")
+
+' 获取文件夹路径参数
+If WScript.Arguments.Count = 0 Then
+    MsgBox "请从右键菜单中调用此程序.", vbExclamation, "缺少参数"
+    WScript.Quit
+End If
+
 folderPath = WScript.Arguments(0)
-exePath = "{app}\ModifyFolderComment.exe"
-objShell.ShellExecute exePath, Chr(34) & folderPath & Chr(34), "", "runas", 1
+
+' 检查文件夹是否存在
+If Not objFSO.FolderExists(folderPath) Then
+    MsgBox "文件夹路径无效.", vbCritical, "错误"
+    WScript.Quit
+End If
+
+' 获取当前脚本目录
+scriptDir = objFSO.GetParentFolderName(WScript.ScriptFullName)
+psScriptPath = objFSO.BuildPath(scriptDir, "ModifyFolderComment.ps1")
+
+' 检查PowerShell脚本是否存在
+If Not objFSO.FileExists(psScriptPath) Then
+    MsgBox "找不到 ModifyFolderComment.ps1 文件.", vbCritical, "错误"
+    WScript.Quit
+End If
+
+' 构建PowerShell命令
+psCommand = "powershell.exe -ExecutionPolicy Bypass -File """ & psScriptPath & """ -FolderPath """ & folderPath & """"
+
+' 执行PowerShell脚本
+objShell.ShellExecute "powershell.exe", "-ExecutionPolicy Bypass -WindowStyle Hidden -File """ & psScriptPath & """ -FolderPath """ & folderPath & """", "", "open", 0

--- a/install_script.iss
+++ b/install_script.iss
@@ -1,50 +1,35 @@
-﻿[Setup]
-AppName=ModifyFolderComment
-AppVersion=1.1.13
+[Setup]
+AppName=ModifyFolderComment PowerShell版
+AppVersion=1.1.64p
 DefaultDirName={commonpf}\ModifyFolderComment
 DefaultGroupName=ModifyFolderComment
-OutputBaseFilename=install
+OutputBaseFilename=install_powershell
 Compression=lzma2
 SolidCompression=yes
-
-[InstallDelete]
-Type: files; Name: "{app}\RunModifyFolderComment.vbs.bak"
+ArchitecturesInstallIn64BitMode=x64
+UninstallDisplayName=ModifyFolderComment PowerShell版
+UninstallDisplayIcon={app}\ModifyFolderComment.ps1
 
 [Files]
-; 包含可执行文件和脚本
-Source: "ModifyFolderComment.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "RunModifyFolderComment.vbs"; DestDir: "{app}"; Flags: ignoreversion
-Source: "ForceRefresh.vbs"; DestDir: "{app}"; Flags: ignoreversion
-
-[Icons]
-Name: "{group}\ModifyFolderComment"; Filename: "{app}\ModifyFolderComment.exe"
+Source: "ModifyFolderComment.ps1"; DestDir: "{app}"; Flags: ignoreversion
+Source: "FolderCommentCore.psm1"; DestDir: "{app}"; Flags: ignoreversion
+Source: "AFC.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Registry]
-; 导入注册表文件
 Root: HKCR; Subkey: "Directory\shell\ModifyFolderComment"; ValueType: string; ValueName: ""; ValueData: "修改文件夹备注"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "Directory\shell\ModifyFolderComment\command"; ValueType: string; ValueName: ""; ValueData: "wscript.exe ""{app}\RunModifyFolderComment.vbs"" ""%1"""; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "Directory\shell\ModifyFolderComment\command"; ValueType: string; ValueName: ""; ValueData: "powershell.exe ""-ExecutionPolicy"" ""Bypass"" ""-File"" ""{app}\ModifyFolderComment.ps1"" ""%1"""; Flags: uninsdeletevalue
+
+[Icons]
+Name: "{group}\修改文件夹备注 (命令行)"; Filename: "powershell.exe"; Parameters: "-File ""{app}\AFC.ps1"" -h"; WorkingDir: "{app}"
+Name: "{group}\卸载 ModifyFolderComment"; Filename: "{uninstallexe}"
 
 [Code]
-procedure ReplaceInFile(const FileName, SearchString, ReplaceString: string);
-var
-  Lines: TArrayOfString;
-  i: Integer;
+function InitializeSetup(): Boolean;
 begin
-  if LoadStringsFromFile(FileName, Lines) then
-  begin
-    for i := 0 to GetArrayLength(Lines) - 1 do
-    begin
-      StringChangeEx(Lines[i], SearchString, ReplaceString, True);
-    end;
-    SaveStringsToFile(FileName, Lines, False);
-  end;
+  Result := True;
+  if MsgBox('此程序需要PowerShell执行权限。安装后可能需要设置执行策略。' + #13#10 + '是否继续安装？', mbConfirmation, MB_YESNO) = IDNO then
+    Result := False;
 end;
 
-procedure CurStepChanged(CurStep: TSetupStep);
-begin
-  if CurStep = ssPostInstall then
-  begin
-    ReplaceInFile(ExpandConstant('{app}\RunModifyFolderComment.vbs'), '{app}', ExpandConstant('{app}'));
-    ReplaceInFile(ExpandConstant('{app}\ForceRefresh.vbs'), '{app}', ExpandConstant('{app}'));
-  end;
-end;
+[Run]
+Filename: "powershell.exe"; Parameters: "-Command ""Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force"""; Flags: runhidden; Description: "设置PowerShell执行策略"


### PR DESCRIPTION
## Summary

- Extract shared logic (Set-FolderInfoTip, Get-FolderInfoTip, Invoke-FolderRefresh) to `FolderCommentCore.psm1`
- Add `Escape-InfoTipComment` to prevent ini injection attacks
- Add `Write-OperationLog` for operation logging
- Add proper COM object release via `ReleaseComObject`
- Enhance path validation (normalize path, verify it's a directory)
- Replace VBS wrapper with direct PowerShell invocation in registry
- Add `RunModifyFolderComment.ps1` as PowerShell wrapper alternative

## Files Changed

- `FolderCommentCore.psm1` - New shared module
- `ModifyFolderComment.ps1` - Uses module, ~60% rewrite
- `AFC.ps1` - Uses module, ~84% rewrite
- `install_script.iss` - Updated registry format
- `AddContextMenuOption.reg` - Updated registry format
- `CLAUDE.md` - Updated with new architecture info
- `OPTIMIZATION_ISSUES.md` - Updated with optimization status

## Test Plan

- [ ] Test right-click context menu on a folder
- [ ] Test CLI via AFC.ps1
- [ ] Verify desktop.ini is created with correct attributes (Hidden+System)
- [ ] Verify folder comment displays in Explorer
- [ ] Test uninstall/reinstall via installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)